### PR TITLE
fix: apply target refresh rate to newly-enabled displays in staged mode

### DIFF
--- a/src/Core/ProfileManager.cs
+++ b/src/Core/ProfileManager.cs
@@ -863,6 +863,22 @@ private bool ApplyStagedConfiguration(List<DisplayConfigHelper.DisplayConfigInfo
                     return false;
                 }
 
+                // Explicitly apply resolution and refresh rate for monitors that were just activated in this phase.
+                // ApplyDisplayTopology only flips the active/inactive flags - it does not select a target mode,
+                // so a newly-enabled monitor can come up at whatever default mode Windows picks (often 60Hz).
+                var newlyEnabledConfigs = targetConfigs
+                    .Where(tc => tc.IsEnabled && !phase1Configs.Any(p => p.TargetId == tc.TargetId && p.SourceId == tc.SourceId))
+                    .ToList();
+
+                foreach (var config in newlyEnabledConfigs)
+                {
+                    logger.Debug($"Phase 2: Changing mode for newly-enabled {config.DeviceName} to {config.Width}x{config.Height}@{config.RefreshRate}Hz");
+                    if (!DisplayHelper.ChangeResolution(config.DeviceName, config.Width, config.Height, (int)config.RefreshRate))
+                    {
+                        logger.Warn($"Phase 2: Failed to change resolution for newly-enabled display {config.DeviceName}.");
+                    }
+                }
+
                 // Apply final positions for all monitors
                 if (!DisplayConfigHelper.ApplyDisplayPosition(targetConfigs))
                 {


### PR DESCRIPTION
Phase 2 of staged application only flipped the active/inactive path flags via ApplyDisplayTopology, without selecting a target mode. A monitor transitioning from disabled to enabled could therefore come up at whatever default refresh rate Windows picked (often 60Hz) instead of the rate stored in the profile. Explicitly call ChangeResolution for newly-enabled displays after Phase 2, mirroring what Phase 1 already does for already-active displays.